### PR TITLE
Add missing prefix void to paged-collection-with-order example

### DIFF
--- a/examples/paged-collection-with-order/second.ttl
+++ b/examples/paged-collection-with-order/second.ttl
@@ -6,6 +6,7 @@
 @prefix shacl: <http://www.w3.org/ns/shacl#>.
 @prefix lc: <http://semweb.mmlab.be/ns/linkedconnections#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix void: <http://rdfs.org/ns/void#>.
 
 <https://graph.irail.be/sncb/connections> a hydra:Collection ;
                                           rdfs:label "All arrivals and departures of Trains in Belgium"@en ;


### PR DESCRIPTION
Hi,

The void prefix from this example was missing.

The `<second.ttl>`-node is also missing on this page. I'm wondering if this needs to be added.
