### PR TITLE
specs/6-compatibility.md: typo / readability

### DIFF
--- a/specs/6-compatibility.md
+++ b/specs/6-compatibility.md
@@ -12,7 +12,7 @@ When this is done, also `hydra:member` can be used instead of `tree:member`.
 
 `hydra:totalItems` can be used to indicate the total amount of elements in the collection.
 
-Hydra paging controls such as `hydra:next`and `hydra:previous`are semantically equivalent to a `tree:Relation` element that only contains a `tree:node` property. These do not provide any additional information to a client traversing a collection; the discovered node retains the value constraints from the current node. 
+Hydra paging controls such as `hydra:next` and `hydra:previous` are semantically equivalent to a `tree:Relation` element that only contains a `tree:node` property. These do not provide any additional information to a client traversing a collection; the discovered node retains the value constraints from the current node. 
 
 ### Activity Streams 2.0 ### {#activitystreams}
 


### PR DESCRIPTION
This commit adds spaces before two words that are attached to a code fence.