### PR TITLE
Update wording to improve clarity on tree:view

### DIFF
--- a/01-tree-specification.bs
+++ b/01-tree-specification.bs
@@ -23,7 +23,7 @@ Abstract:
 The TREE specification introduces these core concepts:
  * `tree:Collection` is a set of members. It typically has these properties when described in a node:
      - `tree:member` points at the first focus node from which to retrieve and extract all quads of a member
-     - `tree:view` points to the `tree:Node` you are currently visiting
+     - `tree:view` points to the `tree:Node` you are currently visiting if multiple views exist, or the sole `tree:Node` if there is only one
      - `tree:shape` indicates the [[!SHACL]] shape (exactly one) to which each member in the collection adheres
  * `tree:Node` is a page in the search tree
      - `tree:relation` points at relations to other nodes
@@ -120,14 +120,15 @@ In one tree, completeness MUST be guaranteed, unless indicated otherwise (as is 
 
 A client SHOULD be initiated using a URL.
 The client MUST dereference the URL, which will result in a set of [[!rdf-concepts]] triples or quads.
-When the URL after all redirects, is used in a triple `?c tree:view <> .`, a client MUST assume the URL after redirects is an identifier of the intended root node of the collection in `?c`.
+When the URL after all redirects (`R`) is used in a triple `?c tree:view <> .`, a client MUST assume `R` is an identifier of the intended root node of the collection in `?c`.
 
 Note: Dereferencing in this specification also means parsing the RDF triples or quads from the HTTP response. TREE does not limit the content-types that can be used to represent RDF triples. Client developers should do a best-effort for their community.
 
-If there is no such triple, then the client MUST check whether the URL before redirects (`E`) has been used in a pattern `<E> tree:view ?N.` where there’s exactly one `?N`, then the algorithm MUST return `?N` as the rootnode and `E` as the collection.
+If there is no such triple, then the client MUST check whether the URL before redirects (`E`) has been used in a pattern `<E> tree:view ?N.` where there’s exactly one `?N`. If found, the algorithm MUST return `?N` as the root node and `E` as the collection.
+Additionally, if the triple `<E> tree:view ?N` is not found, the client MUST check whether the URL after redirects (`R`) has been used in a pattern `<R> tree:view ?N.`. If found, the algorithm MUST return `?N` as the root node and `R` as the collection.
 
-The client then MUST dereference the identified rootnode (if it did not do that already) and merge those quads with the already found quads.
-It now MUST look for a potential search forms that MAY be linked, either i) on top of the rootnode, or ii) on top of the entity linked through `tree:viewDescription`, using `tree:search`.
+The client then MUST dereference the identified root node (if it did not do that already) and merge those quads with the already found quads.
+It now MUST look for a potential search forms that MAY be linked, either i) on top of the root node, or ii) on top of the entity linked through `tree:viewDescription`, using `tree:search`.
 
 In case it is not done using an unambiguous URL, clients MAY implement the report on [Discovery and Context Information (work in progress)](https://w3id.org/tree/specification/discovery).
 This report also explains how clients MAY implement support for extracting context information such as provenance, contact points, etc.


### PR DESCRIPTION
Currently the Overview does not allow for the case that the tree:view triple is contained in the RDF document describing the Collection (which is at a different URL than the sole view of that Collection).
However, that should be allowed based on the following sentence in the Initialization: "If there is no such triple, then the client MUST check whether the URL before redirects (`E`) has been used in a pattern `<E> tree:view ?N.` where there’s exactly one `?N`, then the algorithm MUST return `?N` as the rootnode and `E` as the collection."

Additionally, the Initialization section currently does not allow the case where the triple `<R> tree:view ?view .` is present at URL `R`. An example to illustrate the problem:
1. The client is initiated using URL `http://mytree.org/feed`
2. When dereferencing this URL, the client gets redirected to `https://www.mytree.org/feed`
3. The client checks if it finds the triple `?c tree:view <URL>` but it does not because the view is at `https://www.mytree.org/feed/default`
4. If not found, it then checks for the triple `<E> tree:view ?view .`, so `<http://mytree.org/feed> tree:view ?view .`, but it does not find any because the triple present is `<https://www.mytree.org/feed> tree:view <https://www.myldes.org/feed/default> .`